### PR TITLE
Detect synchronous blocks

### DIFF
--- a/test/eventLoopStats.js
+++ b/test/eventLoopStats.js
@@ -23,4 +23,21 @@ describe('eventLoopStats', function() {
     }, 1000);
   });
 
+  it('should actually detect a blocked eventloop', function(done) {
+    // Get stats to reset max
+    eventLoopStats.sense();
+    // On the next tick, block for 500ms
+    setTimeout(function() {
+      var waitUntill = new Date(Date.now() + 500);
+      while(waitUntill > new Date()) {};
+
+      // On the next tick, detect stats again
+      setTimeout(function() {
+        var stats = eventLoopStats.sense();
+        expect(stats.max).to.be.gt(450);
+        done();
+      }, 0);
+    }, 0)
+  });
+
 });

--- a/test/eventLoopStats.js
+++ b/test/eventLoopStats.js
@@ -2,7 +2,6 @@ var eventLoopStats = require('..');
 var expect = require('chai').expect;
 
 describe('eventLoopStats', function() {
-
   it('should expose a sense function', function() {
     expect(eventLoopStats.sense).to.be.a('function');
   });
@@ -23,21 +22,61 @@ describe('eventLoopStats', function() {
     }, 1000);
   });
 
-  it('should actually detect a blocked eventloop', function(done) {
-    // Get stats to reset max
+  // This pattern will usually allow for at least _two_ on_check calls between
+  // the two sense calls. Check the next test for a slightly different pattern.
+  it('should detect a blocked event loop', function(done) {
+    // Call sense to reset max.
     eventLoopStats.sense();
-    // On the next tick, block for 500ms
+    // On the next tick, block for 500ms.
     setTimeout(function() {
       var waitUntill = new Date(Date.now() + 500);
-      while(waitUntill > new Date()) {};
+      // Block event loop with busy waiting.
+      while (waitUntill > new Date()) {}
 
-      // On the next tick, detect stats again
+      // On the next tick, detect stats again - the 500 ms block should have
+      // been noticed.
       setTimeout(function() {
         var stats = eventLoopStats.sense();
-        expect(stats.max).to.be.gt(450);
+        expect(stats.max).to.be.gte(490);
+        expect(stats.max).to.be.lt(2000);
+        expect(stats.sum).to.be.gte(490);
+        expect(stats.sum).to.be.lt(2000);
+
+        // At least two on_check calls should have happened (older Node.js versions will call it more often).
+        expect(stats.num).to.be.gte(2);
+
+        // Since there are at least two on_check calls, min and max should be different.
+        expect(stats.min).to.be.gte(0);
+        expect(stats.min).to.be.lt(stats.max);
+
         done();
       }, 0);
-    }, 0)
+    }, 0);
   });
 
+  // This pattern will typically allow for only _one_ on_check call between the
+  // two sense calls (at least on more recent Node.js versions). Check the
+  // previous test for a slightly different pattern.
+  it('one on_check call should suffice to report correct max duration ', function(done) {
+    // Call sense to reset max.
+    eventLoopStats.sense();
+    var now = Date.now();
+    var end = now + 50;
+    setTimeout(function() {
+      // After 100ms, call sense again - the 50ms block (see below) should have been noticed.
+      var stats = eventLoopStats.sense();
+      expect(stats.max).to.be.gte(40);
+      expect(stats.max).to.be.lt(1000);
+      expect(stats.sum).to.be.gte(40);
+      expect(stats.sum).to.be.lt(1000);
+
+      // Only one on_check call might have happened.
+      expect(stats.num).to.gte(1);
+
+      done();
+    }, 100);
+
+    // Directly block for 50ms right in this tick, synchronously.
+    while (Date.now() < end) {}
+  });
 });


### PR DESCRIPTION
This PR does two things:

* Merges downstream changes from https://github.com/ably-forks/event-loop-stats/pull/1 
* Fixes #6

The reproduction case given in #6 still didn't work after applying the changes from the ably-forks PR. That PR introduces a `previous_now` variable and the handling of that had a little issue: The fix for #6 (after applying the downstream PR) is basically not resetting `previous_now` to `maxPossibleNumber` on every `sense()` call. When we do this, we require _two_ `on_check` calls to happen between two consecutive `sense` calls. The reason is that we can obviously never calculate a duration on the first `on_check` after resetting `previous_now`.

I also actually see no good reason to reset `previous_now`. Resetting `min`, `max`, `num` & `sum` makes sense, but AFAICT there is no reason to _not_ compare the timestamp of the first `on_check` after a `sense` to the timestamp of the `on_check` call before the `sense` call.
